### PR TITLE
Fix typing of deprecated aliases

### DIFF
--- a/commands2/__init__.py
+++ b/commands2/__init__.py
@@ -101,17 +101,22 @@ __all__ = [
 ]
 
 if not TYPE_CHECKING:
+
     def __getattr__(attr):
         if attr == "SubsystemBase":
             import warnings
-    
-            warnings.warn("SubsystemBase is deprecated", DeprecationWarning, stacklevel=2)
+
+            warnings.warn(
+                "SubsystemBase is deprecated", DeprecationWarning, stacklevel=2
+            )
             return Subsystem
-    
+
         if attr == "CommandBase":
             import warnings
-    
+
             warnings.warn("CommandBase is deprecated", DeprecationWarning, stacklevel=2)
             return Command
-    
-        raise AttributeError("module {!r} has no attribute " "{!r}".format(__name__, attr))
+
+        raise AttributeError(
+            "module {!r} has no attribute " "{!r}".format(__name__, attr)
+        )

--- a/commands2/__init__.py
+++ b/commands2/__init__.py
@@ -118,5 +118,5 @@ if not TYPE_CHECKING:
             return Command
 
         raise AttributeError(
-            "module {!r} has no attribute " "{!r}".format(__name__, attr)
+            f"module {__name__!r} has no attribute {attr!r}"
         )

--- a/commands2/__init__.py
+++ b/commands2/__init__.py
@@ -48,6 +48,8 @@ from .waitcommand import WaitCommand
 from .waituntilcommand import WaitUntilCommand
 from .wrappercommand import WrapperCommand
 
+from typing import TYPE_CHECKING
+
 __all__ = [
     "cmd",
     "Command",
@@ -98,18 +100,18 @@ __all__ = [
     "Trigger",  # was here in 2023
 ]
 
-
-def __getattr__(attr):
-    if attr == "SubsystemBase":
-        import warnings
-
-        warnings.warn("SubsystemBase is deprecated", DeprecationWarning, stacklevel=2)
-        return Subsystem
-
-    if attr == "CommandBase":
-        import warnings
-
-        warnings.warn("CommandBase is deprecated", DeprecationWarning, stacklevel=2)
-        return Command
-
-    raise AttributeError("module {!r} has no attribute " "{!r}".format(__name__, attr))
+if not TYPE_CHECKING:
+    def __getattr__(attr):
+        if attr == "SubsystemBase":
+            import warnings
+    
+            warnings.warn("SubsystemBase is deprecated", DeprecationWarning, stacklevel=2)
+            return Subsystem
+    
+        if attr == "CommandBase":
+            import warnings
+    
+            warnings.warn("CommandBase is deprecated", DeprecationWarning, stacklevel=2)
+            return Command
+    
+        raise AttributeError("module {!r} has no attribute " "{!r}".format(__name__, attr))

--- a/commands2/__init__.py
+++ b/commands2/__init__.py
@@ -117,6 +117,4 @@ if not TYPE_CHECKING:
             warnings.warn("CommandBase is deprecated", DeprecationWarning, stacklevel=2)
             return Command
 
-        raise AttributeError(
-            f"module {__name__!r} has no attribute {attr!r}"
-        )
+        raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")

--- a/commands2/command.py
+++ b/commands2/command.py
@@ -61,6 +61,7 @@ class Command(Sendable):
     requirements: Set[Subsystem]
 
     if not TYPE_CHECKING:
+
         def __new__(cls, *args, **kwargs) -> Self:
             instance = super().__new__(
                 cls,

--- a/commands2/command.py
+++ b/commands2/command.py
@@ -60,14 +60,15 @@ class Command(Sendable):
 
     requirements: Set[Subsystem]
 
-    def __new__(cls, *args, **kwargs) -> Self:
-        instance = super().__new__(
-            cls,
-        )
-        super().__init__(instance)
-        SendableRegistry.add(instance, cls.__name__)
-        instance.requirements = set()
-        return instance
+    if not TYPE_CHECKING:
+        def __new__(cls, *args, **kwargs) -> Self:
+            instance = super().__new__(
+                cls,
+            )
+            super().__init__(instance)
+            SendableRegistry.add(instance, cls.__name__)
+            instance.requirements = set()
+            return instance
 
     def __init__(self):
         pass

--- a/commands2/command.py
+++ b/commands2/command.py
@@ -60,16 +60,14 @@ class Command(Sendable):
 
     requirements: Set[Subsystem]
 
-    if not TYPE_CHECKING:
-
-        def __new__(cls, *args, **kwargs) -> Self:
-            instance = super().__new__(
-                cls,
-            )
-            super().__init__(instance)
-            SendableRegistry.add(instance, cls.__name__)
-            instance.requirements = set()
-            return instance
+    def __new__(cls, *args, **kwargs) -> Self:
+        instance = super().__new__(
+            cls,
+        )
+        super().__init__(instance)
+        SendableRegistry.add(instance, cls.__name__)
+        instance.requirements = set()
+        return instance
 
     def __init__(self):
         pass

--- a/commands2/subsystem.py
+++ b/commands2/subsystem.py
@@ -28,15 +28,16 @@ class Subsystem(Sendable):
     base for user implementations that handles this.
     """
 
-    def __new__(cls, *arg, **kwargs) -> "Subsystem":
-        instance = super().__new__(cls)
-        super().__init__(instance)
-        SendableRegistry.addLW(instance, cls.__name__, cls.__name__)
-        # add to the scheduler
-        from .commandscheduler import CommandScheduler
+    if not TYPE_CHECKING:
+        def __new__(cls, *arg, **kwargs) -> "Subsystem":
+            instance = super().__new__(cls)
+            super().__init__(instance)
+            SendableRegistry.addLW(instance, cls.__name__, cls.__name__)
+            # add to the scheduler
+            from .commandscheduler import CommandScheduler
 
-        CommandScheduler.getInstance().registerSubsystem(instance)
-        return instance
+            CommandScheduler.getInstance().registerSubsystem(instance)
+            return instance
 
     def __init__(self) -> None:
         pass

--- a/commands2/subsystem.py
+++ b/commands2/subsystem.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Optional
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from .command import Command
@@ -28,17 +29,15 @@ class Subsystem(Sendable):
     base for user implementations that handles this.
     """
 
-    if not TYPE_CHECKING:
+    def __new__(cls, *arg, **kwargs) -> Self:
+        instance = super().__new__(cls)
+        super().__init__(instance)
+        SendableRegistry.addLW(instance, cls.__name__, cls.__name__)
+        # add to the scheduler
+        from .commandscheduler import CommandScheduler
 
-        def __new__(cls, *arg, **kwargs) -> "Subsystem":
-            instance = super().__new__(cls)
-            super().__init__(instance)
-            SendableRegistry.addLW(instance, cls.__name__, cls.__name__)
-            # add to the scheduler
-            from .commandscheduler import CommandScheduler
-
-            CommandScheduler.getInstance().registerSubsystem(instance)
-            return instance
+        CommandScheduler.getInstance().registerSubsystem(instance)
+        return instance
 
     def __init__(self) -> None:
         pass

--- a/commands2/subsystem.py
+++ b/commands2/subsystem.py
@@ -29,6 +29,7 @@ class Subsystem(Sendable):
     """
 
     if not TYPE_CHECKING:
+
         def __new__(cls, *arg, **kwargs) -> "Subsystem":
             instance = super().__new__(cls)
             super().__init__(instance)


### PR DESCRIPTION
This fixes type hints in Pylance. The module `__getattr__` throws off its checking of what types are actually available.

This hides the `__getattr__` from type checkers