### PR TITLE
FunctionalCommand: Assert lifecycle functions are callable

### DIFF
--- a/commands2/functionalcommand.py
+++ b/commands2/functionalcommand.py
@@ -12,7 +12,8 @@ class FunctionalCommand(Command):
     A command that allows the user to pass in functions for each of the basic command methods through
     the constructor. Useful for inline definitions of complex commands - note, however, that if a
     command is beyond a certain complexity it is usually better practice to write a proper class for
-    it than to inline it."""
+    it than to inline it.
+    """
 
     def __init__(
         self,
@@ -29,8 +30,14 @@ class FunctionalCommand(Command):
         :param onExecute: the function to run on command execution
         :param onEnd: the function to run on command end
         :param isFinished: the function that determines whether the command has finished
-        :param requirements: the subsystems required by this command"""
+        :param requirements: the subsystems required by this command
+        """
         super().__init__()
+
+        assert callable(onInit)
+        assert callable(onExecute)
+        assert callable(onEnd)
+        assert callable(isFinished)
 
         self._onInit = onInit
         self._onExecute = onExecute


### PR DESCRIPTION
It's common for less experienced Python programmers to forget to create lambdas, instead accidentally immediately calling a method and passing in `None` into whatever command factory they're using.

Fail early in debug mode (e.g. simulation/tests) so it's more obvious where such an error originates from.