### PR TITLE
One option for adding generic types

### DIFF
--- a/commands2/__init__.py
+++ b/commands2/__init__.py
@@ -2,6 +2,7 @@ from .command import Command, InterruptionBehavior
 
 from . import button
 from . import cmd
+from . import typing
 
 from .commandscheduler import CommandScheduler
 from .conditionalcommand import ConditionalCommand

--- a/commands2/profiledpidcommand.py
+++ b/commands2/profiledpidcommand.py
@@ -5,14 +5,19 @@
 # the WPILib BSD license file in the root directory of this project.
 #
 
-from typing import Any, Callable, Generic, Union
+from typing import Any, Generic
 
 from wpimath.controller import ProfiledPIDController, ProfiledPIDControllerRadians
 from wpimath.trajectory import TrapezoidProfile, TrapezoidProfileRadians
 
 from .command import Command
 from .subsystem import Subsystem
-from .typing import TProfiledPIDController, UseOutputFunction
+from .typing import (
+    FloatOrFloatSupplier,
+    FloatSupplier,
+    TProfiledPIDController,
+    UseOutputFunction,
+)
 
 
 class ProfiledPIDCommand(Command, Generic[TProfiledPIDController]):
@@ -26,8 +31,8 @@ class ProfiledPIDCommand(Command, Generic[TProfiledPIDController]):
     def __init__(
         self,
         controller: TProfiledPIDController,
-        measurementSource: Callable[[], float],
-        goalSource: Union[float, Callable[[], float]],
+        measurementSource: FloatSupplier,
+        goalSource: FloatOrFloatSupplier,
         useOutput: UseOutputFunction,
         *requirements: Subsystem,
     ):

--- a/commands2/profiledpidcommand.py
+++ b/commands2/profiledpidcommand.py
@@ -5,16 +5,17 @@
 # the WPILib BSD license file in the root directory of this project.
 #
 
-from typing import Any, Callable, Union
-
-from .command import Command
-from .subsystem import Subsystem
+from typing import Any, Callable, Generic, Union
 
 from wpimath.controller import ProfiledPIDController, ProfiledPIDControllerRadians
 from wpimath.trajectory import TrapezoidProfile, TrapezoidProfileRadians
 
+from .command import Command
+from .subsystem import Subsystem
+from .typing import TProfiledPIDController, UseOutputFunction
 
-class ProfiledPIDCommand(Command):
+
+class ProfiledPIDCommand(Command, Generic[TProfiledPIDController]):
     """A command that controls an output with a :class:`.ProfiledPIDController`. Runs forever by default -
     to add exit conditions and/or other behavior, subclass this class. The controller calculation and
     output are performed synchronously in the command's execute() method.
@@ -24,10 +25,10 @@ class ProfiledPIDCommand(Command):
 
     def __init__(
         self,
-        controller,
+        controller: TProfiledPIDController,
         measurementSource: Callable[[], float],
         goalSource: Union[float, Callable[[], float]],
-        useOutput: Callable[[float, Any], Any],
+        useOutput: UseOutputFunction,
         *requirements: Subsystem,
     ):
         """Creates a new ProfiledPIDCommand, which controls the given output with a ProfiledPIDController. Goal
@@ -40,6 +41,7 @@ class ProfiledPIDCommand(Command):
         :param requirements:      the subsystems required by this command
         """
 
+        super().__init__()
         if isinstance(controller, ProfiledPIDController):
             self._stateCls = TrapezoidProfile.State
         elif isinstance(controller, ProfiledPIDControllerRadians):
@@ -47,7 +49,7 @@ class ProfiledPIDCommand(Command):
         else:
             raise ValueError(f"unknown controller type {controller!r}")
 
-        self._controller = controller
+        self._controller: TProfiledPIDController = controller
         self._useOutput = useOutput
         self._measurement = measurementSource
         if isinstance(goalSource, (float, int)):

--- a/commands2/profiledpidsubsystem.py
+++ b/commands2/profiledpidsubsystem.py
@@ -7,10 +7,12 @@ from typing import Generic
 from wpimath.trajectory import TrapezoidProfile
 
 from .subsystem import Subsystem
-from .typing import TProfiledPIDController
+from .typing import TProfiledPIDController, TTrapezoidProfileState
 
 
-class ProfiledPIDSubsystem(Subsystem, Generic[TProfiledPIDController]):
+class ProfiledPIDSubsystem(
+    Subsystem, Generic[TProfiledPIDController, TTrapezoidProfileState]
+):
     """
     A subsystem that uses a :class:`wpimath.controller.ProfiledPIDController`
     or :class:`wpimath.controller.ProfiledPIDControllerRadians` to
@@ -49,7 +51,7 @@ class ProfiledPIDSubsystem(Subsystem, Generic[TProfiledPIDController]):
         """
         self._controller.setGoal(goal)
 
-    def useOutput(self, output: float, setpoint: TrapezoidProfile.State):
+    def useOutput(self, output: float, setpoint: TTrapezoidProfileState):
         """
         Uses the output from the controller object.
         """

--- a/commands2/profiledpidsubsystem.py
+++ b/commands2/profiledpidsubsystem.py
@@ -2,14 +2,15 @@
 # Open Source Software; you can modify and/or share it under the terms of
 # the WPILib BSD license file in the root directory of this project.
 
-from typing import Union, cast
+from typing import Generic
 
 from wpimath.trajectory import TrapezoidProfile
 
 from .subsystem import Subsystem
+from .typing import GenericProfiledPIDController
 
 
-class ProfiledPIDSubsystem(Subsystem):
+class ProfiledPIDSubsystem(Subsystem, Generic[GenericProfiledPIDController]):
     """
     A subsystem that uses a :class:`wpimath.controller.ProfiledPIDController`
     or :class:`wpimath.controller.ProfiledPIDControllerRadians` to
@@ -19,12 +20,12 @@ class ProfiledPIDSubsystem(Subsystem):
 
     def __init__(
         self,
-        controller,
+        controller: GenericProfiledPIDController,
         initial_position: float = 0,
     ):
         """Creates a new PIDSubsystem."""
         super().__init__()
-        self._controller = controller
+        self._controller: GenericProfiledPIDController = controller
         self._enabled = False
         self.setGoal(initial_position)
 
@@ -38,7 +39,7 @@ class ProfiledPIDSubsystem(Subsystem):
 
     def getController(
         self,
-    ):
+    ) -> GenericProfiledPIDController:
         """Returns the controller"""
         return self._controller
 

--- a/commands2/profiledpidsubsystem.py
+++ b/commands2/profiledpidsubsystem.py
@@ -25,7 +25,13 @@ class ProfiledPIDSubsystem(
         controller: TProfiledPIDController,
         initial_position: float = 0,
     ):
-        """Creates a new PIDSubsystem."""
+        """
+        Creates a new Profiled PID Subsystem using the provided PID Controller
+
+        :param controller:        the controller that controls the output
+        :param initial_position:  the initial value of the process variable
+
+        """
         super().__init__()
         self._controller: TProfiledPIDController = controller
         self._enabled = False
@@ -46,15 +52,11 @@ class ProfiledPIDSubsystem(
         return self._controller
 
     def setGoal(self, goal):
-        """
-        Sets the goal state for the subsystem.
-        """
+        """Sets the goal state for the subsystem."""
         self._controller.setGoal(goal)
 
     def useOutput(self, output: float, setpoint: TTrapezoidProfileState):
-        """
-        Uses the output from the controller object.
-        """
+        """Uses the output from the controller object."""
         raise NotImplementedError(f"{self.__class__} must implement useOutput")
 
     def getMeasurement(self) -> float:
@@ -75,7 +77,5 @@ class ProfiledPIDSubsystem(
         self.useOutput(0, TrapezoidProfile.State())
 
     def isEnabled(self) -> bool:
-        """
-        Returns whether the controller is enabled.
-        """
+        """Returns whether the controller is enabled."""
         return self._enabled

--- a/commands2/profiledpidsubsystem.py
+++ b/commands2/profiledpidsubsystem.py
@@ -7,10 +7,10 @@ from typing import Generic
 from wpimath.trajectory import TrapezoidProfile
 
 from .subsystem import Subsystem
-from .typing import GenericProfiledPIDController
+from .typing import TProfiledPIDController
 
 
-class ProfiledPIDSubsystem(Subsystem, Generic[GenericProfiledPIDController]):
+class ProfiledPIDSubsystem(Subsystem, Generic[TProfiledPIDController]):
     """
     A subsystem that uses a :class:`wpimath.controller.ProfiledPIDController`
     or :class:`wpimath.controller.ProfiledPIDControllerRadians` to
@@ -20,12 +20,12 @@ class ProfiledPIDSubsystem(Subsystem, Generic[GenericProfiledPIDController]):
 
     def __init__(
         self,
-        controller: GenericProfiledPIDController,
+        controller: TProfiledPIDController,
         initial_position: float = 0,
     ):
         """Creates a new PIDSubsystem."""
         super().__init__()
-        self._controller: GenericProfiledPIDController = controller
+        self._controller: TProfiledPIDController = controller
         self._enabled = False
         self.setGoal(initial_position)
 
@@ -39,7 +39,7 @@ class ProfiledPIDSubsystem(Subsystem, Generic[GenericProfiledPIDController]):
 
     def getController(
         self,
-    ) -> GenericProfiledPIDController:
+    ) -> TProfiledPIDController:
         """Returns the controller"""
         return self._controller
 

--- a/commands2/typing.py
+++ b/commands2/typing.py
@@ -1,0 +1,7 @@
+from typing import TypeVar
+
+from wpimath.controller import ProfiledPIDController, ProfiledPIDControllerRadians
+
+GenericProfiledPIDController = TypeVar(
+    "GenericProfiledPIDController", ProfiledPIDControllerRadians, ProfiledPIDController
+)

--- a/commands2/typing.py
+++ b/commands2/typing.py
@@ -1,8 +1,10 @@
-from typing import Protocol, TypeVar
+from typing import Callable, Protocol, TypeVar, Union
 
+from typing_extensions import TypeAlias
 from wpimath.controller import ProfiledPIDController, ProfiledPIDControllerRadians
 from wpimath.trajectory import TrapezoidProfile, TrapezoidProfileRadians
 
+# Generic Types
 TProfiledPIDController = TypeVar(
     "TProfiledPIDController", ProfiledPIDControllerRadians, ProfiledPIDController
 )
@@ -13,10 +15,16 @@ TTrapezoidProfileState = TypeVar(
 )
 
 
+# Protocols - Structural Typing
 class UseOutputFunction(Protocol):
 
-    def __init__(self): ...
+    def __init__(self, *args, **kwargs) -> None: ...
 
     def __call__(self, t: float, u: TTrapezoidProfileState) -> None: ...
 
     def accept(self, t: float, u: TTrapezoidProfileState) -> None: ...
+
+
+# Type Aliases
+FloatSupplier: TypeAlias = Callable[[], float]
+FloatOrFloatSupplier: TypeAlias = Union[float, Callable[[], float]]

--- a/commands2/typing.py
+++ b/commands2/typing.py
@@ -1,7 +1,22 @@
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 from wpimath.controller import ProfiledPIDController, ProfiledPIDControllerRadians
+from wpimath.trajectory import TrapezoidProfile, TrapezoidProfileRadians
 
-GenericProfiledPIDController = TypeVar(
-    "GenericProfiledPIDController", ProfiledPIDControllerRadians, ProfiledPIDController
+TProfiledPIDController = TypeVar(
+    "TProfiledPIDController", ProfiledPIDControllerRadians, ProfiledPIDController
 )
+TTrapezoidProfileState = TypeVar(
+    "TTrapezoidProfileState",
+    TrapezoidProfileRadians.State,
+    TrapezoidProfile.State,
+)
+
+
+class UseOutputFunction(Protocol):
+
+    def __init__(self): ...
+
+    def __call__(self, t: float, u: TTrapezoidProfileState) -> None: ...
+
+    def accept(self, t: float, u: TTrapezoidProfileState) -> None: ...


### PR DESCRIPTION
It seems like there is a strong desire to implement better typing in the robotpy-commands-v2 library.  There are potentially several ways to improve typing.  The approach shown here uses TypeVar to create a generic type of ProfiledPIDController, named GenericProfiledPIDController.  The generic type is defined in new typing.py file.  The new generic type is then used in profiledpidsubsystem.py file as a type hint.  See the file differences for more details.

Advantages:
- Eliminates the use of type Unions.
- Should be easy to maintain as the WPI C++ library evolves over time.