### PR TITLE
Improve typing support by adding a py.typed marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.dll
 *.so
 *.dylib
-py.typed
 
 /build
 /dist

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
     author_email="robotpy@googlegroups.com",
     description="WPILib command framework v2",
     url="https://github.com/robotpy/robotpy-commands-v2",
+    package_data={"commands2": ["py.typed"]},
     packages=["commands2"],
     install_requires=[
         "wpilib<2025,>=2024.2.1.2",


### PR DESCRIPTION
For robotpy applications to make use of the type hints in the robotpy-commands-v2 package, the package needs to indicate to the type checker that it supports type hints.  Adding a py.typed marker to the package files will mark the package as supporting type hints.