### PR TITLE
Revert "[cmd] Add ScheduleCommand decorator" (#71)

### DIFF
--- a/commands2/command.py
+++ b/commands2/command.py
@@ -384,22 +384,6 @@ class Command(Sendable):
 
         return ProxyCommand(self)
 
-    def fork(self, *commands: Command) -> ProxyCommand:
-        """
-        Decorates this command to run "forked" by wrapping it in a ScheduleCommand. Use this for
-        "forking off" from command compositions when the user does not wish to extend the command's
-        requirements to the entire command composition. Note that if run from a composition, the
-        composition will not know about the status of the scheduled commands, and will treat this
-        command as finishing instantly. Commands can be added to this and will be scheduled in order
-        with this command scheduled first., see the `WPILib docs <https://docs.wpilib.org/en/stable/docs/software/commandbased/command-compositions.html#scheduling-other-commands>`_ for a full explanation.
-
-        :param other: other commands to schedule along with this one. This command is scheduled first.
-        :returns: the decorated command
-        """
-        from .schedulecommand import ScheduleCommand
-
-        return ScheduleCommand(self, [self] + commands)
-
     def unless(self, condition: Callable[[], bool]) -> ConditionalCommand:
         """
         Decorates this command to only run if this condition is not met. If the command is already


### PR DESCRIPTION
https://github.com/robotpy/robotpy-commands-v2/pull/79#issuecomment-2564956240 mentioned that the corresponding change to WPILib for #71 was rejected.

This reverts commit 80068977c14cc2c93cf821b87594c97f723ca939 (#71), reversing changes made to 81f6129bb566147a767f1ff56b0060d4131c83c9.